### PR TITLE
Improved small-tsu substitution in _romajiToKana

### DIFF
--- a/src/coffee/wanakana.coffee
+++ b/src/coffee/wanakana.coffee
@@ -196,7 +196,11 @@ wanakana._romajiToKana = (roma, options, ignoreCase = false) ->
       wanakana._isCharConsonant(chunkLC.charAt(0)) and
       chunk.charAt(0) == chunk.charAt(1)
         chunkSize = 1
-        chunkLC = chunk = "っ"
+        # Return katakana ッ if chunk is uppercase, otherwise return hiragana っ
+        if wanakana._isCharInRange(chunk.charAt(0), wanakana.UPPERCASE_START, wanakana.UPPERCASE_END)
+          chunkLC = chunk = "ッ"
+        else
+          chunkLC = chunk = "っ"
 
       kanaChar = wanakana.R_to_J[chunkLC]
       # DEBUG


### PR DESCRIPTION
I added a check to determine which type of small-tsu should be returned when double-consonants are detected (ッ for KATAKANA, っ for hiragana). I only modified the CoffeeJS script, I didn't set up CoffeeJS to compile the actual Javascript. This is my first foray into CoffeeJS, and I just dove into the code and tried to follow the syntax - I apologize if it doesn't jive with the rest of the code.

You can see what I'm talking about if you go to http://wanakana.com/ and type "NEKKU". You'll see that it returns "ネっク" instead of "ネック". This revision should fix that.
![wanakana_bug](https://f.cloud.github.com/assets/5166470/1405233/57772376-3d20-11e3-8215-79e8a8c1796c.png)
