### PR TITLE
Fix for erratic cursor behavior on Android

### DIFF
--- a/lib/wanakana.js
+++ b/lib/wanakana.js
@@ -63,13 +63,15 @@ wanakana._onInput = function(event) {
   });
   if (normalizedInputString !== newText) {
     input.value = newText;
-    androidFix = (_ref = startingCursor === 0) != null ? _ref : {
-      1: 0
-    };
-    newLength = newText.length;
-    newCursor = startingCursor - startingLength + newLength;
-    fixedCursor = androidFix ? newLength : newCursor;
-    return input.selectionStart = input.selectionEnd = fixedCursor;
+    
+    if (typeof input.selectionStart == "number") {
+		input.selectionStart = input.selectionEnd = input.value.length;
+    } else if (typeof input.createTextRange != "undefined") {
+		input.focus();
+		var range = input.createTextRange();
+		range.collapse(false);
+		range.select();
+    }
   }
 };
 


### PR DESCRIPTION
This addresses an issue WanaKana was having with the cursor jumping around erratically when entering text in Chrome on Android. The cursor should now always move to the end of whatever text is inside the input element.

I only edited the non-minified JS file in /lib/, I'm not familiar enough with CoffeeScript to modify the source file.
