### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "wanakana",
+  "version": "1.3.6",
+  "description": "JS library that transliterates between japanese kana and roman letters.",
+  "homepage": "http://wanakana.com/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/WaniKani/WanaKana.git"
+  },
+  "main": ["lib/wanakana.js"],
+  "keywords": ["Japanese", "kana", "katakana", "hiragana", "romaji"],
+  "authors": ["Mims H. Wright"],
+  "license": "MIT",
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-jshint": "~0.6.4",
+    "grunt-contrib-qunit": "~0.2.2",
+    "grunt-contrib-uglify": "~0.2.4",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-coffeelint": "~0.0.7",
+    "grunt-bump": "~0.0.11",
+    "grunt-open": "~0.2.2",
+    "grunt-text-replace": "~0.3.9"
+  }
+}


### PR DESCRIPTION
This commit adds a `bower.json` for the project for [Bower](http://bower.io/). (In general it would seem Bower is a better way to install this lib than NPM)

To make this work, **please register `wanakana` name itself on Bower.**
