### PR TITLE
docs(readme): Update example import statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install wanakana
 ```
 
 ```javascript
-import wanakana from 'wanakana';
+import * as wanakana from 'wanakana';
 // or
 import { toKana, isRomaji } from 'wanakana';
 ```


### PR DESCRIPTION
The module doesn't have a default export so the example import would result in an undefined `wanakana` object.

