### PR TITLE
Feature/Extend kanji set to include iteration character in isKanji check

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -60,6 +60,7 @@ export const UPPERCASE_ZENKAKU_END = 0xff3a;
 export const HIRAGANA_START = 0x3041;
 export const HIRAGANA_END = 0x3096;
 export const KATAKANA_START = 0x30a1;
+export const KANJI_ITERATION_MARK = 0x3005; // 々
 export const KATAKANA_END = 0x30fc;
 export const KANJI_START = 0x4e00;
 export const KANJI_END = 0x9faf;
@@ -84,7 +85,12 @@ const CJK_SYMBOLS_PUNCTUATION = [0x3000, 0x303f];
 const COMMON_CJK = [0x4e00, 0x9fff];
 const RARE_CJK = [0x3400, 0x4dbf];
 
-export const KANA_RANGES = [HIRAGANA_CHARS, KATAKANA_CHARS, KANA_PUNCTUATION, HANKAKU_KATAKANA];
+export const KANA_RANGES = [
+  HIRAGANA_CHARS,
+  KATAKANA_CHARS,
+  KANA_PUNCTUATION,
+  HANKAKU_KATAKANA,
+];
 
 export const JA_PUNCTUATION_RANGES = [
   CJK_SYMBOLS_PUNCTUATION,

--- a/src/utils/isCharKanji.js
+++ b/src/utils/isCharKanji.js
@@ -1,7 +1,4 @@
-import {
-  KANJI_START,
-  KANJI_END,
-} from '../constants';
+import { KANJI_START, KANJI_END, KANJI_ITERATION_MARK } from '../constants';
 
 import isCharInRange from './isCharInRange';
 /**
@@ -10,7 +7,10 @@ import isCharInRange from './isCharInRange';
  * @return {Boolean}
  */
 function isCharKanji(char = '') {
-  return isCharInRange(char, KANJI_START, KANJI_END);
+  return (
+    isCharInRange(char, KANJI_START, KANJI_END) ||
+    char.charCodeAt(0) === KANJI_ITERATION_MARK
+  );
 }
 
 export default isCharKanji;

--- a/test/utils/isCharKanji.test.js
+++ b/test/utils/isCharKanji.test.js
@@ -10,6 +10,7 @@ describe('isCharKanji', () => {
     expect(isCharKanji('腹')).toBe(true);
     expect(isCharKanji('一')).toBe(true); // kanji for いち・1 - not a long hyphen
     expect(isCharKanji('ー')).toBe(false); // long hyphen
+    expect(isCharKanji('々')).toBe(true); // kanji for iteration e.g. 人々
     expect(isCharKanji('は')).toBe(false);
     expect(isCharKanji('ナ')).toBe(false);
     expect(isCharKanji('n')).toBe(false);


### PR DESCRIPTION
Currently, the check for kanji does not include the char for representing a kanji repetition, e.g. in 人々 the 々 is ignored. Added a test and an extra check for this character since it is counted as a kanji.

A reference to the character here:
[Reference](https://jisho.org/word/%E3%80%85)

By the way I am very grateful for all the work in this package and making it public, it helps a lot!