### PR TITLE
chore: Add Kotlin port to readme and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,4 @@ The following ports have been created by the community:
 * Java ([MasterKale/WanaKanaJava](https://github.com/MasterKale/WanaKanaJava))
 * Rust ([PSeitz/wana_kana_rust](https://github.com/PSeitz/wana_kana_rust))
 * Swift ([profburke/WanaKanaSwift](https://github.com/profburke/WanaKanaSwift))
+* Kotlin ([esnaultdev/wanakana-kt](https://github.com/esnaultdev/wanakana-kt))

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -324,6 +324,12 @@ wanakana.bind(input);</code></pre>
                   <a href="https://github.com/profburke/WanaKanaSwift" title="View WanaKanaSwift">WanaKanaSwift</a>
                 </td>
               </tr>
+              <tr>
+                <td>Kotlin</td>
+                <td>
+                  <a href="https://github.com/esnaultdev/wanakana-kt" title="View WanaKanaKotlin">WanaKanaKotlin</a>
+                </td>
+              </tr>
             </tbody>
           </table>
 


### PR DESCRIPTION
I've ported Wanakana to Kotlin to have an up-to-date alternative to WanakanaJava.
This PR adds the port to the README and the website, similarly to other ports.

Thanks for the great library :+1:
