### PR TITLE
fix: replace previous mapping when provided with a new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,10 @@
     "shelljs": "^0.8.5",
     "static-server": "^3.0.0"
   },
+   "dependencies": {
+    "dequal": "^2.0.2",
+    "memoize-one": "^6.0.0"
+  },
   "lint-staged": {
     "src/**/*.js": [
       "npm run format --",

--- a/src/toRomaji.js
+++ b/src/toRomaji.js
@@ -1,13 +1,31 @@
+import memoizeOne from 'memoize-one';
+import { dequal } from 'dequal';
+
 import mergeWithDefaultOptions from './utils/mergeWithDefaultOptions';
 import katakanaToHiragana from './utils/katakanaToHiragana';
 import isKatakana from './isKatakana';
 import { getKanaToRomajiTree } from './utils/kanaToRomajiMap';
 import { applyMapping, mergeCustomMapping } from './utils/kanaMapping';
 
+// memoize and deeply compare args so we only recreate when necessary
+export const createKanaToRomajiMap = memoizeOne(
+  (romanization, customRomajiMapping) => {
+    let map = getKanaToRomajiTree(romanization);
+
+    if (customRomajiMapping) {
+      map = mergeCustomMapping(map, customRomajiMapping);
+    }
+
+    return map;
+  },
+  dequal
+);
+
 /**
  * Convert kana to romaji
  * @param  {String} kana text input
  * @param  {DefaultOptions} [options=defaultOptions]
+ * @param  {Object} map custom mapping
  * @return {String} converted text
  * @example
  * toRomaji('ひらがな　カタカナ')
@@ -19,30 +37,40 @@ import { applyMapping, mergeCustomMapping } from './utils/kanaMapping';
  * toRomaji('つじぎり', { customRomajiMapping: { じ: 'zi', つ: 'tu', り: 'li' } });
  * // => 'tuzigili'
  */
-export function toRomaji(input = '', options = {}) {
-  const mergedOptions = mergeWithDefaultOptions(options);
-  // just throw away the substring index information and just concatenate all the kana
-  return splitIntoRomaji(input, mergedOptions)
+export function toRomaji(input = '', options = {}, map) {
+  const config = mergeWithDefaultOptions(options);
+
+  if (!map) {
+    map = createKanaToRomajiMap(
+      config.romanization,
+      config.customRomajiMapping
+    );
+  }
+
+  // just throw away the substring index information and simply concatenate all the kana
+  return splitIntoRomaji(input, config, map)
     .map((romajiToken) => {
       const [start, end, romaji] = romajiToken;
-      const makeUpperCase = options.upcaseKatakana && isKatakana(input.slice(start, end));
+      const makeUpperCase =
+        config.upcaseKatakana && isKatakana(input.slice(start, end));
       return makeUpperCase ? romaji.toUpperCase() : romaji;
     })
     .join('');
 }
 
-let customMapping = null;
-function splitIntoRomaji(input, options) {
-  let map = getKanaToRomajiTree(options);
-
-  if (options.customRomajiMapping) {
-    if (customMapping == null) {
-      customMapping = mergeCustomMapping(map, options.customRomajiMapping);
-    }
-    map = customMapping;
+function splitIntoRomaji(input, options, map) {
+  if (!map) {
+    map = createKanaToRomajiMap(
+      options.romanization,
+      options.customRomajiMapping
+    );
   }
 
-  return applyMapping(katakanaToHiragana(input, toRomaji, true), map, !options.IMEMode);
+  return applyMapping(
+    katakanaToHiragana(input, toRomaji, true),
+    map,
+    !options.IMEMode
+  );
 }
 
 export default toRomaji;

--- a/src/utils/kanaToRomajiMap.js
+++ b/src/utils/kanaToRomajiMap.js
@@ -59,7 +59,19 @@ const SMALL_AIUEO = {
   ぇ: 'e',
   ぉ: 'o',
 };
-const YOON_KANA = ['き', 'に', 'ひ', 'み', 'り', 'ぎ', 'び', 'ぴ', 'ゔ', 'く', 'ふ'];
+const YOON_KANA = [
+  'き',
+  'に',
+  'ひ',
+  'み',
+  'り',
+  'ぎ',
+  'び',
+  'ぴ',
+  'ゔ',
+  'く',
+  'ふ',
+];
 const YOON_EXCEPTIONS = {
   し: 'sh',
   ち: 'ch',
@@ -108,10 +120,10 @@ function getKanaToHepburnTree() {
   return kanaToHepburnMap;
 }
 
-export function getKanaToRomajiTree(fullOptions) {
-  switch (fullOptions.romanization) {
+export function getKanaToRomajiTree(romanization) {
+  switch (romanization) {
     case ROMANIZATIONS.HEPBURN:
-      return getKanaToHepburnTree(fullOptions);
+      return getKanaToHepburnTree();
     default:
       return {};
   }
@@ -129,9 +141,11 @@ function createKanaToHepburnMap() {
     subtreeOf(jsymbol)[''] = symbol;
   });
 
-  [...Object.entries(SMALL_Y), ...Object.entries(SMALL_AIUEO)].forEach(([roma, kana]) => {
-    setTrans(roma, kana);
-  });
+  [...Object.entries(SMALL_Y), ...Object.entries(SMALL_AIUEO)].forEach(
+    ([roma, kana]) => {
+      setTrans(roma, kana);
+    }
+  );
 
   // きゃ -> kya
   YOON_KANA.forEach((kana) => {

--- a/test/utils/customMapping.test.js
+++ b/test/utils/customMapping.test.js
@@ -33,6 +33,33 @@ describe('Test custom mappings options', () => {
     ).toBe('tuzigili');
   });
 
+  it('will replace previous custom mappings', () => {
+    expect(
+      toRomaji('つじぎり', {
+        customRomajiMapping: createCustomMapping({ じ: 'zi', つ: 'tu', り: 'li' }),
+      })
+    ).toBe('tuzigili');
+
+    expect(
+      toRomaji('つじぎり', {
+        customRomajiMapping: createCustomMapping({ じ: 'bi', つ: 'bu', り: 'bi' }),
+      })
+    ).toBe('bubigibi');
+
+    expect(
+      toKana('wanakana', {
+        customKanaMapping: createCustomMapping({ na: 'に', ka: 'Bana' }),
+      })
+    ).toBe('わにBanaに');
+
+    expect(
+      toKana('wanakana', {
+        customKanaMapping: createCustomMapping({ na: 'り', ka: 'Cabana' }),
+      })
+    ).toBe('わりCabanaり');
+  });
+
+
   it('will accept a plain object and merge it internally via createCustomMapping()', () => {
     expect(
       toKana('wanakana', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+dequal@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
@@ -5082,6 +5087,11 @@ mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 memorystream@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
We were replacing custom mappings only when a previous one did not exist.

This PR ensures we rebuild mappings anytime they change, but also skips running the map creation when unnecessary (via memoize and deep equal).

This also adds 2 new dependencies (which are <1kb combined), whereas we used to be dependency free. I don't know if that was by chance or philosophical when this project was started. Any thoughts on this? Do you mind the change? @mimshwright @vietqhoang 

However our current build contains a lot of backwards browser compatibility cruft that is outdated and unneeded these days. I think we should tackle that it a separate PR (which would likely shed a lot of weight).

Fixes #129