### PR TITLE
Add Unpkg field to released package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Change Log
 
 All notable changes to this project will be documented in this file.
@@ -24,23 +26,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Add any unpublished changes here as they are made, for easy reference come release time.
 -->
 
+## [5.0.!] - 2022-04-15
+
+### Fixed
+
+- Unpkg should now properly source the correct module for use in the browser as a script tag
+
 ## [5.0.0] - 2022-04-15
 
 ### Fixed
 
-- When a custom mapping was provided in options and then a different one was given, we only replaced the mapping with the new one when a previous one did not exist. Now we will always replace the custom mapping when it changes. https://github.com/WaniKani/WanaKana/pull/132
+- When a custom mapping was provided in options and then a different one was given, we only replaced the mapping with the new one when a previous one did not exist. Now we will always replace the custom mapping when it changes. <https://github.com/WaniKani/WanaKana/pull/132>
 
 ### Added
 
-- Support for converting some k-- constructions. https://github.com/WaniKani/WanaKana/issues/126
-- Allow user to ignore converting long vowel mark in toHiragana. https://github.com/WaniKani/WanaKana/issues/128
-
+- Support for converting some k-- constructions. <https://github.com/WaniKani/WanaKana/issues/126>
+- Allow user to ignore converting long vowel mark in toHiragana. <https://github.com/WaniKani/WanaKana/issues/128>
 
 ### Changed
 
 - The UMD build now only includes polyfills for browserslist defaults (> 0.5%, last 2 versions, Firefox ESR, not dead - at time of writing) which drops support for IE.
 - Node support is now 12+ (though likely would continue to work fine on older versions)
-
 
 ## [4.0.2] - 2018-04-30
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -37,6 +37,7 @@ const PACKAGE_JSON = {
     'main': 'cjs/index.js',
     'react-native': 'cjs/index.js',
     'module': 'esm/index.js',
+    'unpkg': 'wanakana.min.js',
     'engines': {
       node: '>=12',
     },


### PR DESCRIPTION
Fixes #136 
Unpkg used to fallback to main, but that is now an ES module build.
This PR directs unpkg to the correct module for use directly in a script tag.
