### PR TITLE
fix: k conversions

### DIFF
--- a/src/utils/romajiToKanaMap.js
+++ b/src/utils/romajiToKanaMap.js
@@ -131,14 +131,8 @@ const AIUEO_CONSTRUCTIONS = {
 // https://github.com/WaniKani/WanaKana/issues/126
 const K_CONSTRUCTIONS = {
   kwi: 'くぃ',
-  kuxi: 'くぃ',
-  kuli: 'くぃ',
   kwe: 'くぇ',
-  kuxe: 'くぇ',
-  kule: 'くぇ',
   kwo: 'くぉ',
-  kuxo: 'くぉ',
-  kulo: 'くぉ',
 };
 
 /* eslint-enable */


### PR DESCRIPTION
https://github.com/WaniKani/WanaKana/pull/130 (https://github.com/WaniKani/WanaKana/pull/130/commits/d339c12a0bd85ad5c330ead4b51e9fa467e0429a) introduced a bug where typing 'ku' does not turn into 'く' anymore, only after another character is typed.
kuxi/kuli/kuxe/kule/kuxo/kulo conversions are redundant and removing them solves the issue.
No need to change related tests.