### PR TITLE
fix: bind options

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -65,8 +65,8 @@ try {
   }
 
   log('Running tests...');
-  if (execFail(exec('npm-run-all lint:js test'))) {
-    logError('The test command did not exit cleanly. Aborting release.');
+  if (execFail(exec('npm-run-all lint:js test cypress:test'))) {
+    logError('The tests did not exit cleanly. Aborting release.');
     exit(1);
   }
   logSuccess('Tests were successful.');

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -60,16 +60,30 @@ try {
 
   log('Have you updated the changelog?');
   if (!readline.keyInYN('Yes I have!')) {
-    log('OK. Do that, then try again!');
+    log("OK, you're forgiven. But go do that now, then try again.");
     exit(0);
   }
 
+  log('Smoke-test code...');
+  if (execFail(exec('npm run lint:js'))) {
+    logError('The lint command did not exit cleanly. Aborting release.');
+    exit(1);
+  }
+  log('Looks good!');
+
+  log('Compiling build for testing...');
+  if (execFail(exec('npm run build'))) {
+    logError('The build command did not exit cleanly. Aborting release.');
+    exit(1);
+  }
+  log('Looks great!');
+
   log('Running tests...');
-  if (execFail(exec('npm-run-all lint:js test cypress:test'))) {
+  if (execFail(exec('npm-run-all test cypress:test'))) {
     logError('The tests did not exit cleanly. Aborting release.');
     exit(1);
   }
-  logSuccess('Tests were successful.');
+  logSuccess('Kicking wickets!');
 
   const versionLoc = path.resolve('VERSION');
   const version = fs.readFileSync(versionLoc, 'utf8').trim();
@@ -105,7 +119,7 @@ try {
     exit(1);
   }
 
-  log('Building dist files...');
+  log('Building final dist files with updated version...');
   if (execFail(exec('npm run build'))) {
     logError('The build command did not exit cleanly. Aborting release.');
     exit(1);

--- a/src/toKana.js
+++ b/src/toKana.js
@@ -72,9 +72,8 @@ export function toKana(input = '', options = {}, map) {
         return input.slice(start);
       }
       const enforceHiragana = config.IMEMode === TO_KANA_METHODS.HIRAGANA;
-      const enforceKatakana =
-        config.IMEMode === TO_KANA_METHODS.KATAKANA ||
-        [...input.slice(start, end)].every(isCharUpperCase);
+      const enforceKatakana = config.IMEMode === TO_KANA_METHODS.KATAKANA
+        || [...input.slice(start, end)].every(isCharUpperCase);
 
       return enforceHiragana || !enforceKatakana
         ? kana

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -11,25 +11,39 @@ let LISTENERS = [];
  */
 export function makeOnInput(options) {
   let prevInput;
+
   // Enforce IMEMode if not already specified
   const mergedConfig = Object.assign({}, mergeWithDefaultOptions(options), {
     IMEMode: options.IMEMode || true,
   });
-  const preConfiguredMap = createRomajiToKanaMap(mergedConfig);
+
+  const preConfiguredMap = createRomajiToKanaMap(
+    mergedConfig.IMEMode,
+    mergedConfig.useObsoleteKana,
+    mergedConfig.customKanaMapping
+  );
+
   const triggers = [
     ...Object.keys(preConfiguredMap),
     ...Object.keys(preConfiguredMap).map((char) => char.toUpperCase()),
   ];
 
   return function onInput({ target }) {
-    if (target.value !== prevInput && target.dataset.ignoreComposition !== 'true') {
+    if (
+      target.value !== prevInput
+      && target.dataset.ignoreComposition !== 'true'
+    ) {
       convertInput(target, mergedConfig, preConfiguredMap, triggers, prevInput);
     }
   };
 }
 
 export function convertInput(target, options, map, triggers, prevInput) {
-  const [head, textToConvert, tail] = splitInput(target.value, target.selectionEnd, triggers);
+  const [head, textToConvert, tail] = splitInput(
+    target.value,
+    target.selectionEnd,
+    triggers
+  );
   const convertedText = toKana(textToConvert, options, map);
   const changed = textToConvert !== convertedText;
 
@@ -83,7 +97,9 @@ export function untrackListeners({ id: targetId }) {
 }
 
 export function findListeners(el) {
-  return el && LISTENERS.find(({ id }) => id === el.getAttribute('data-wanakana-id'));
+  return (
+    el && LISTENERS.find(({ id }) => id === el.getAttribute('data-wanakana-id'))
+  );
 }
 
 // Handle non-terminal inserted input conversion:
@@ -100,8 +116,14 @@ export function splitInput(text = '', cursor = 0, triggers = []) {
   } else if (cursor > 0) {
     [head, toConvert, tail] = workBackwards(text, cursor);
   } else {
-    [head, toConvert] = takeWhileAndSlice(text, (char) => !triggers.includes(char));
-    [toConvert, tail] = takeWhileAndSlice(toConvert, (char) => !isJapanese(char));
+    [head, toConvert] = takeWhileAndSlice(
+      text,
+      (char) => !triggers.includes(char)
+    );
+    [toConvert, tail] = takeWhileAndSlice(
+      toConvert,
+      (char) => !isJapanese(char)
+    );
   }
 
   return [head, toConvert, tail];

--- a/test/utils/dom.test.js
+++ b/test/utils/dom.test.js
@@ -2,7 +2,7 @@ import { splitInput } from '../../src/utils/dom';
 import { createRomajiToKanaMap } from '../../src/toKana';
 
 describe('splitInput', () => {
-  const preConfiguredMap = createRomajiToKanaMap({ IMEMode: true });
+  const preConfiguredMap = createRomajiToKanaMap(true /* IMEMode */);
   const triggers = [
     ...Object.keys(preConfiguredMap),
     ...Object.keys(preConfiguredMap).map((char) => char.toUpperCase()),
@@ -12,21 +12,15 @@ describe('splitInput', () => {
     it('wa2なn', () => expect(splitInput("wa2なn'", 0, triggers)).toEqual(['', 'wa', "2なn'"]));
     it('n', () => expect(splitInput("n'な", 0, triggers)).toEqual(['', "n'", 'な']));
     it('なn', () => expect(splitInput("なn'", 0, triggers)).toEqual(['な', "n'", '']));
-    it('12１２aaａａ', () =>
-      expect(splitInput('12１２aaａａ.。', 0, triggers)).toEqual(['12１２', 'aa', 'ａａ.。']));
+    it('12１２aaａａ', () => expect(splitInput('12１２aaａａ.。', 0, triggers)).toEqual(['12１２', 'aa', 'ａａ.。']));
     it('わn', () => expect(splitInput("わn'な", 0, triggers)).toEqual(['わ', "n'", 'な']));
     it('わn', () => expect(splitInput('わn な', 0, triggers)).toEqual(['わ', 'n ', 'な']));
     it('わshinな', () => expect(splitInput('わshinな', 5, triggers)).toEqual(['わ', 'shin', 'な']));
     it('かnyaな', () => expect(splitInput('かnyaな', 4, triggers)).toEqual(['か', 'nya', 'な']));
-    it('わRA-MENな', () =>
-      expect(splitInput('わRA-MENな', 0, triggers)).toEqual(['わ', 'RA-MEN', 'な']));
-    it('こsこrこsこ', () =>
-      expect(splitInput('こsこrこsこ', 0, triggers)).toEqual(['こ', 's', 'こrこsこ']));
-    it('こsこrこshiこ', () =>
-      expect(splitInput('こsこrこshiこ', 8, triggers)).toEqual(['こsこrこ', 'shi', 'こ']));
-    it('こsこrこsこ', () =>
-      expect(splitInput('こsこrこsこ', 4, triggers)).toEqual(['こsこ', 'r', 'こsこ']));
-    it('こsoこrこsこ', () =>
-      expect(splitInput('こsoこrこsこ', 3, triggers)).toEqual(['こ', 'so', 'こrこsこ']));
+    it('わRA-MENな', () => expect(splitInput('わRA-MENな', 0, triggers)).toEqual(['わ', 'RA-MEN', 'な']));
+    it('こsこrこsこ', () => expect(splitInput('こsこrこsこ', 0, triggers)).toEqual(['こ', 's', 'こrこsこ']));
+    it('こsこrこshiこ', () => expect(splitInput('こsこrこshiこ', 8, triggers)).toEqual(['こsこrこ', 'shi', 'こ']));
+    it('こsこrこsこ', () => expect(splitInput('こsこrこsこ', 4, triggers)).toEqual(['こsこ', 'r', 'こsこ']));
+    it('こsoこrこsこ', () => expect(splitInput('こsoこrこsこ', 3, triggers)).toEqual(['こ', 'so', 'こrこsこ']));
   });
 });


### PR DESCRIPTION
I missed updating a small change in how params were passed (object changed to single vars for the memoize deep equal check) for one of our helper methods.

This affected the ability to pass two of the options to the bind function in the browser.

This PR fixes that issue, and also adds a few more checks and balances to the release process to ensure the cypress tests run, and that they run on the minified production build (to match real usage).

I wonder how long it would take to convert src to typescript 🤔, this would have been caught immediately 😿  