### PR TITLE
prevent binding already bound elements

### DIFF
--- a/cypress/integration/test_input_spec.js
+++ b/cypress/integration/test_input_spec.js
@@ -67,6 +67,20 @@ describe('binding & unbinding', () => {
       .clear();
   });
 
+  it('should not bind already bound inputs', () => {
+    cy
+      .get('#input')
+      .wkBind()
+      .wkBind()
+      .type('wanakana')
+      .should('have.value', 'わなかな')
+      .wkUnbind()
+      .clear()
+      .type('wanakana')
+      .should('have.value', 'wanakana')
+      .clear();
+  });
+
   it('should handle concurrent separate bindings', () => {
     const [sel1, sel2, sel3] = ['#input', '#input2', '#textarea'];
     cy

--- a/src/bind.js
+++ b/src/bind.js
@@ -25,6 +25,9 @@ function bind(element = {}, options = {}, debug = false) {
       )})`
     );
   }
+  if (element.hasAttribute('data-wanakana-id')) {
+    return;
+  }
   const onInput = makeOnInput(options);
   const id = newId();
   element.setAttribute('data-wanakana-id', id);


### PR DESCRIPTION
This PR prevents elements being bound more than once.  When an element is bound multiple times it can't be unbound cleanly.  When the element is bound a second time the already bound event listener is orphaned and wont be garbage collected as the LISTENERS array in the dom utils still holds a reference.  When unbind is called it will leave the first onInput event listener bound to the element.  This PR should fix this issue.

Note:  I thought it would be better to return early as opposed to throwing an error as the impact on existing codebases would be lower.
