### PR TITLE
replace or remove added attributes when element is unbound

### DIFF
--- a/cypress/integration/test_input_spec.js
+++ b/cypress/integration/test_input_spec.js
@@ -81,6 +81,49 @@ describe('binding & unbinding', () => {
       .clear();
   });
 
+  it('should remove added html attributes when unbound', () => {
+    cy
+      .get('#input')
+      .wkBind()
+      .should('have.attr', 'lang', 'ja')
+      .and('have.attr', 'autoCapitalize', 'none')
+      .and('have.attr', 'autoCorrect', 'off')
+      .and('have.attr', 'autoComplete', 'off')
+      .and('have.attr', 'spellCheck', 'false')
+      .wkUnbind()
+      .then((input) => {
+        expect(input[0].hasAttribute('lang')).to.be.false;
+        expect(input[0].hasAttribute('autoCapitalize')).to.be.false;
+        expect(input[0].hasAttribute('autoCorrect')).to.be.false;
+        expect(input[0].hasAttribute('autoComplete')).to.be.false;
+        expect(input[0].hasAttribute('spellCheck')).to.be.false;
+      });
+  });
+
+  it('should replace added html attributes when unbound', () => {
+    cy
+      .get('#input')
+      .then((input) => {
+        input[0].setAttribute('lang', 'de');
+        input[0].setAttribute('autoCapitalize', 'words');
+        input[0].setAttribute('autoComplete', 'name');
+        input[0].setAttribute('autoCorrect', 'on');
+        input[0].setAttribute('spellCheck', 'true');
+      })
+      .wkBind()
+      .should('have.attr', 'lang', 'ja')
+      .and('have.attr', 'autoCapitalize', 'none')
+      .and('have.attr', 'autoCorrect', 'off')
+      .and('have.attr', 'autoComplete', 'off')
+      .and('have.attr', 'spellCheck', 'false')
+      .wkUnbind()
+      .should('have.attr', 'lang', 'de')
+      .and('have.attr', 'autoCapitalize', 'words')
+      .and('have.attr', 'autoComplete', 'name')
+      .and('have.attr', 'autoCorrect', 'on')
+      .and('have.attr', 'spellCheck', 'true');
+  });
+
   it('should handle concurrent separate bindings', () => {
     const [sel1, sel2, sel3] = ['#input', '#input2', '#textarea'];
     cy

--- a/src/bind.js
+++ b/src/bind.js
@@ -30,12 +30,20 @@ function bind(element = {}, options = {}, debug = false) {
   }
   const onInput = makeOnInput(options);
   const id = newId();
-  element.setAttribute('data-wanakana-id', id);
-  element.setAttribute('lang', 'ja');
-  element.setAttribute('autoCapitalize', 'none');
-  element.setAttribute('autoCorrect', 'off');
-  element.setAttribute('autoComplete', 'off');
-  element.setAttribute('spellCheck', 'false');
+  const attributes = [
+    { name: 'data-wanakana-id', value: id },
+    { name: 'lang', value: 'ja' },
+    { name: 'autoCapitalize', value: 'none' },
+    { name: 'autoCorrect', value: 'off' },
+    { name: 'autoComplete', value: 'off' },
+    { name: 'spellCheck', value: 'false' },
+  ];
+  const previousAttributes = {};
+  attributes.forEach((attribute) => {
+    previousAttributes[attribute.name] = element.getAttribute(attribute.name);
+    element.setAttribute(attribute.name, attribute.value);
+  });
+  element.dataset.previousAttributes = JSON.stringify(previousAttributes);
   element.addEventListener('input', onInput);
   element.addEventListener('compositionupdate', onComposition);
   element.addEventListener('compositionend', onComposition);

--- a/src/unbind.js
+++ b/src/unbind.js
@@ -15,7 +15,15 @@ export function unbind(element, debug = false) {
     );
   }
   const { inputHandler, compositionHandler } = listeners;
-  element.removeAttribute('data-wanakana-id');
+  const attributes = JSON.parse(element.dataset.previousAttributes);
+  Object.keys(attributes).forEach((key) => {
+    if (attributes[key]) {
+      element.setAttribute(key, attributes[key]);
+    } else {
+      element.removeAttribute(key);
+    }
+  });
+  element.removeAttribute('data-previous-attributes');
   element.removeAttribute('data-ignore-composition');
   element.removeEventListener('input', inputHandler);
   element.removeEventListener('compositionstart', compositionHandler);


### PR DESCRIPTION
when the input is bound attributes are added or overwritten. When the input is unbound this PR reinstates overridden attributes and removes added attributes.

I opted to store all attributes that were added or manipulated in a map and save the map in a data attribute that could be referenced when the element is unbound. I felt this approach was easier than only adding overridden attributes to the map and having some conditional logic to determine whether to remove or replace.  This way the unbinding code shouldn't get out of step with the binding code as any attribute added in bind will get the correct treatment when unbound.

I ran in to an issue with cypress where i wanted to write e.g. `.should('not.have.attr', 'lang')`, but that seemed to break the chaining as the subject was replaced.

closes #152 