### PR TITLE
Added go implementation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,4 @@ The following ports have been created by the community:
 * Swift ([profburke/WanaKanaSwift](https://github.com/profburke/WanaKanaSwift))
 * Kotlin ([esnaultdev/wanakana-kt](https://github.com/esnaultdev/wanakana-kt))
 * C# ([kmoroz/WanaKanaShaapu](https://github.com/kmoroz/WanaKanaShaapu))
+* Go ([deelawn/wanakana](https://github.com/deelawn/wanakana))


### PR DESCRIPTION
This adds a go implementation to the readme.

Would it be possible for someone to explain the intended behavior of the `convertEnding` boolean that is used in the JS implementation? Apart from binding and unbinding elements, this is the only aspect that functionally differs from the original implementation; it currently does nothing.