### PR TITLE
[Breaking] Feature: include '々' iteration character in kanji, exclude from JA punctuation

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,3 @@
-{}
+{
+  "singleQuote": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Add any unpublished changes here as they are made, for easy reference come release time.
 -->
 
+## [5.2.0] - 2023-09-30
+
+### Fixed
+
+The iteration mark `々` was considered punctuation due to where it lies in unicode (alongside other punctuation). This caused some oddities in Wanakana when splitting characters. Since `々` acts like a kanji character in words, it is no longer considered punctuation in Wanakana. See #163 for further discussion.
+
+- `isKanji()` now returns true for `々`
+- `isPunctuation()` now returns false for `々`
+- `tokenize()` no longer splits on `々`
+- `stripOkurigana()` no longer splits on `々`
+
 ## [5.1.0] - 2023-02-03
 
 ### Fixed

--- a/src/constants.js
+++ b/src/constants.js
@@ -67,8 +67,10 @@ export const KATAKANA_START = 0x30a1;
 export const KATAKANA_END = 0x30fc;
 export const KANJI_START = 0x4e00;
 export const KANJI_END = 0x9faf;
-export const PROLONGED_SOUND_MARK = 0x30fc;
-export const KANA_SLASH_DOT = 0x30fb;
+
+export const KANJI_ITERATION_MARK = 0x3005; // 々
+export const PROLONGED_SOUND_MARK = 0x30fc; // ー
+export const KANA_SLASH_DOT = 0x30fb; // ・
 
 const ZENKAKU_NUMBERS = [0xff10, 0xff19];
 const ZENKAKU_UPPERCASE = [UPPERCASE_ZENKAKU_START, UPPERCASE_ZENKAKU_END];

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -77,26 +77,29 @@ export function getType(input, compact = false) {
  * tokenize('感じ')
  * // ['感', 'じ']
  *
+ * tokenize('人々')
+ * // ['人々']
+ *
  * tokenize('truly 私は悲しい')
  * // ['truly', ' ', '私', 'は', '悲', 'しい']
  *
  * tokenize('truly 私は悲しい', { compact: true })
  * // ['truly ', '私は悲しい']
  *
- * tokenize('5romaji here...!?漢字ひらがな４カタ　カナ「ＳＨＩＯ」。！')
- * // [ '5', 'romaji', ' ', 'here', '...!?', '漢字', 'ひらがな', 'カタ', '　', 'カナ', '４', '「', 'ＳＨＩＯ', '」。！']
+ * tokenize('5romaji here...!?人々漢字ひらがな４カタ　カナ「ＳＨＩＯ」。！')
+ * // [ '5', 'romaji', ' ', 'here', '...!?', '人々漢字', 'ひらがな', 'カタ', '　', 'カナ', '４', '「', 'ＳＨＩＯ', '」。！']
  *
- * tokenize('5romaji here...!?漢字ひらがな４カタ　カナ「ＳＨＩＯ」。！', { compact: true })
- * // [ '5', 'romaji here', '...!?', '漢字ひらがなカタ　カナ', '４「', 'ＳＨＩＯ', '」。！']
+ * tokenize('5romaji here...!?人々漢字ひらがな４カタ　カナ「ＳＨＩＯ」。！', { compact: true })
+ * // [ '5', 'romaji here', '...!?', '人々漢字ひらがなカタ　カナ', '４「', 'ＳＨＩＯ', '」。！']
  *
- * tokenize('5romaji here...!?漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', { detailed: true })
+ * tokenize('5romaji here...!?人々漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', { detailed: true })
  * // [
  *  { type: 'englishNumeral', value: '5' },
  *  { type: 'en', value: 'romaji' },
  *  { type: 'space', value: ' ' },
  *  { type: 'en', value: 'here' },
  *  { type: 'englishPunctuation', value: '...!?' },
- *  { type: 'kanji', value: '漢字' },
+ *  { type: 'kanji', value: '人々漢字' },
  *  { type: 'hiragana', value: 'ひらがな' },
  *  { type: 'katakana', value: 'カタ' },
  *  { type: 'space', value: '　' },
@@ -109,12 +112,12 @@ export function getType(input, compact = false) {
  *  { type: 'other', value: 'لنذهب' },
  * ]
  *
- * tokenize('5romaji here...!?漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', { compact: true, detailed: true})
+ * tokenize('5romaji here...!?人々漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', { compact: true, detailed: true})
  * // [
  *  { type: 'other', value: '5' },
  *  { type: 'en', value: 'romaji here' },
  *  { type: 'other', value: '...!?' },
- *  { type: 'ja', value: '漢字ひらがなカタ　カナ' },
+ *  { type: 'ja', value: '人々漢字ひらがなカタ　カナ' },
  *  { type: 'other', value: '４「' },
  *  { type: 'ja', value: 'ＳＨＩＯ' },
  *  { type: 'other', value: '」。！' },

--- a/src/utils/isCharIterationMark.js
+++ b/src/utils/isCharIterationMark.js
@@ -1,0 +1,14 @@
+import isEmpty from './isEmpty';
+import { KANJI_ITERATION_MARK } from '../constants';
+
+/**
+ * Returns true if char is '々'
+ * @param  {String} char to test
+ * @return {Boolean}
+ */
+function isCharIterationMark(char = '') {
+  if (isEmpty(char)) return false;
+  return char.charCodeAt(0) === KANJI_ITERATION_MARK;
+}
+
+export default isCharIterationMark;

--- a/src/utils/isCharJapanesePunctuation.js
+++ b/src/utils/isCharJapanesePunctuation.js
@@ -1,14 +1,15 @@
 import isEmpty from './isEmpty';
 import { JA_PUNCTUATION_RANGES } from '../constants';
 import isCharInRange from './isCharInRange';
+import isCharIterationMark from './isCharIterationMark';
 
 /**
- * Tests a character. Returns true if the character is considered English punctuation.
+ * Tests a character. Returns true if the character is considered Japanese punctuation.
  * @param  {String} char character string to test
  * @return {Boolean}
  */
 function isCharJapanesePunctuation(char = '') {
-  if (isEmpty(char)) return false;
+  if (isEmpty(char) || isCharIterationMark(char)) return false;
   return JA_PUNCTUATION_RANGES.some(([start, end]) => isCharInRange(char, start, end));
 }
 

--- a/src/utils/isCharKanji.js
+++ b/src/utils/isCharKanji.js
@@ -1,16 +1,14 @@
-import {
-  KANJI_START,
-  KANJI_END,
-} from '../constants';
+import { KANJI_START, KANJI_END } from '../constants';
 
 import isCharInRange from './isCharInRange';
+import isCharIterationMark from './isCharIterationMark';
 /**
  * Tests a character. Returns true if the character is a CJK ideograph (kanji).
  * @param  {String} char character string to test
  * @return {Boolean}
  */
 function isCharKanji(char = '') {
-  return isCharInRange(char, KANJI_START, KANJI_END);
+  return isCharInRange(char, KANJI_START, KANJI_END) || isCharIterationMark(char);
 }
 
 export default isCharKanji;

--- a/test/core/isKanji.test.js
+++ b/test/core/isKanji.test.js
@@ -7,6 +7,7 @@ describe('isKanji()', () => {
   });
   it('切腹 is kanji', () => expect(isKanji('切腹')).toBe(true));
   it('刀 is kanji', () => expect(isKanji('刀')).toBe(true));
+  it('人々 is kanji', () => expect(isKanji('人々')).toBe(true));
   it('emoji are not kanji', () => expect(isKanji('🐸')).toBe(false));
   it('あ is not kanji', () => expect(isKanji('あ')).toBe(false));
   it('ア is not kanji', () => expect(isKanji('ア')).toBe(false));

--- a/test/core/stripOkurigana.test.js
+++ b/test/core/stripOkurigana.test.js
@@ -13,6 +13,7 @@ describe.only('stripOkurigana', () => {
     expect(stripOkurigana('踏み込む')).toBe('踏み込');
     expect(stripOkurigana('使い方')).toBe('使い方');
     expect(stripOkurigana('申し申し')).toBe('申し申');
+    expect(stripOkurigana('人々')).toBe('人々');
     expect(stripOkurigana('お腹')).toBe('お腹');
     expect(stripOkurigana('お祝い')).toBe('お祝');
   });

--- a/test/core/tokenize.test.js
+++ b/test/core/tokenize.test.js
@@ -12,19 +12,20 @@ describe('tokenize', () => {
     expect(tokenize('フフ')).toEqual(['フフ']);
     expect(tokenize('ふふフフ')).toEqual(['ふふ', 'フフ']);
     expect(tokenize('阮咸')).toEqual(['阮咸']);
+    expect(tokenize('人々')).toEqual(['人々']);
     expect(tokenize('感じ')).toEqual(['感', 'じ']);
     expect(tokenize('私は悲しい')).toEqual(['私', 'は', '悲', 'しい']);
     expect(tokenize('ok لنذهب!')).toEqual(['ok', ' ', 'لنذهب', '!']);
   });
 
   it('handles mixed input', () => {
-    expect(tokenize('5romaji here...!?漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！')).toEqual([
+    expect(tokenize('5romaji here...!?人々漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！')).toEqual([
       '5',
       'romaji',
       ' ',
       'here',
       '...!?',
-      '漢字',
+      '人々漢字',
       'ひらがな',
       'カタ',
       '　',
@@ -39,14 +40,14 @@ describe('tokenize', () => {
   describe('options', () => {
     it('{compact: true}', () => {
       expect(
-        tokenize('5romaji here...!?漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', {
+        tokenize('5romaji here...!?人々漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', {
           compact: true,
         })
       ).toEqual([
         '5',
         'romaji here',
         '...!?',
-        '漢字ひらがなカタ　カナ',
+        '人々漢字ひらがなカタ　カナ',
         '４「',
         'ＳＨＩＯ',
         '」。！',
@@ -57,7 +58,7 @@ describe('tokenize', () => {
 
     it('{detailed: true}', () => {
       expect(
-        tokenize('5romaji here...!?漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', {
+        tokenize('5romaji here...!?人々漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', {
           detailed: true,
         })
       ).toEqual([
@@ -66,7 +67,7 @@ describe('tokenize', () => {
         { type: 'space', value: ' ' },
         { type: 'en', value: 'here' },
         { type: 'englishPunctuation', value: '...!?' },
-        { type: 'kanji', value: '漢字' },
+        { type: 'kanji', value: '人々漢字' },
         { type: 'hiragana', value: 'ひらがな' },
         { type: 'katakana', value: 'カタ' },
         { type: 'space', value: '　' },
@@ -82,7 +83,7 @@ describe('tokenize', () => {
 
     it('{ compact: true, detailed: true}', () => {
       expect(
-        tokenize('5romaji here...!?漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', {
+        tokenize('5romaji here...!?人々漢字ひらがなカタ　カナ４「ＳＨＩＯ」。！ لنذهب', {
           compact: true,
           detailed: true,
         })
@@ -90,7 +91,7 @@ describe('tokenize', () => {
         { type: 'other', value: '5' },
         { type: 'en', value: 'romaji here' },
         { type: 'other', value: '...!?' },
-        { type: 'ja', value: '漢字ひらがなカタ　カナ' },
+        { type: 'ja', value: '人々漢字ひらがなカタ　カナ' },
         { type: 'other', value: '４「' },
         { type: 'ja', value: 'ＳＨＩＯ' },
         { type: 'other', value: '」。！' },

--- a/test/utils/isCharKanji.test.js
+++ b/test/utils/isCharKanji.test.js
@@ -8,8 +8,9 @@ describe('isCharKanji', () => {
 
   it('passes parameter tests', () => {
     expect(isCharKanji('腹')).toBe(true);
-    expect(isCharKanji('一')).toBe(true); // kanji for いち・1 - not a long hyphen
+    expect(isCharKanji('一')).toBe(true); // kanji for '-' (いち・1) not a long hyphen
     expect(isCharKanji('ー')).toBe(false); // long hyphen
+    expect(isCharKanji('々')).toBe(true); // kanji for iteration (人々・ひとびと)
     expect(isCharKanji('は')).toBe(false);
     expect(isCharKanji('ナ')).toBe(false);
     expect(isCharKanji('n')).toBe(false);

--- a/test/utils/isCharPunctuation.test.js
+++ b/test/utils/isCharPunctuation.test.js
@@ -14,6 +14,7 @@ describe('isCharPunctuation', () => {
     expect(isCharPunctuation('a')).toBe(false);
     expect(isCharPunctuation('ふ')).toBe(false);
     expect(isCharPunctuation('字')).toBe(false);
+    expect(isCharPunctuation('々')).toBe(false);
     expect(isCharPunctuation('')).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #113

Currently, Wanakana considers `々` to be punctuation (due to where it lies in unicode ranges, alongside other pure punctuation symbols), though in practice it functions like a kanji character. This causes minor issues such as `tokenize()` splitting up words like `人々` incorrectly and `isKanji()` reporting false for `人々`.

This PR now considers `々` to be a kanji character, and excludes it from punctuation checks.
Please see modified tests to see which functions are affected and #113 for prior discussion, as well as https://github.com/DJTB/react-furi/pull/6.

This doesn't really affect the core usage of Wanakana (as an IME) but peripheral utils that we provide. Whenever 々 comes up currently it is behaving incorrectly, so despite considering this a `fix` I don't want consumers updating if they see a patch bump (`5.1.1`). Since it changes existing behaviour perhaps it should be a major release?

@mimshwright @scottnicolson @vietqhoang do you have any concerns merging this?
Do you prefer a major `6.0.0` or minor `5.2.0` with breaking changes listed in release/changelog?
