### PR TITLE
Fix optional params within the stripOkurigana function

### DIFF
--- a/src/stripOkurigana.js
+++ b/src/stripOkurigana.js
@@ -11,7 +11,7 @@ const isInvalidMatcher = (input, matchKanji) =>
 /**
  * Strips [Okurigana](https://en.wikipedia.org/wiki/Okurigana)
  * @param  {String} input text
- * @param  {{ leading: Boolean | undefined, matchKanji: string | undefined }} [options={ leading: false, matchKanji: '' }] optional config
+ * @param  {{ leading?: Boolean, matchKanji?: string }} [options={ leading: false, matchKanji: '' }] optional config
  * @return {String} text with okurigana removed
  * @example
  * stripOkurigana('踏み込む')


### PR DESCRIPTION
After an issue was reported in #141 I did a double check to see if there were any other instances of `type | undefined` being used instead of `param?: type`. One instance is fixed in #172 but I believe this one should also be fixed.

Not sure what I was thinking here using `| undefined` in my original PR. That's my bad.